### PR TITLE
Introduce pattern for program options

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -17,8 +17,10 @@ endif ()
 
 add_custom_target(
         format
-        COMMAND ${CMAKE_SOURCE_DIR}/run-clang-format.py -r ${CMAKE_SOURCE_DIR}/
+        COMMAND ${CMAKE_SOURCE_DIR}/run-clang-format.py -r ${CMAKE_SOURCE_DIR}/scapremai
 )
+
+include_directories(${CMAKE_SOURCE_DIR})
 
 add_library(scapremai_mapried_sampling
         STATIC

--- a/src/cpp/conanfile.txt
+++ b/src/cpp/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
 boost/1.72.0
 jsoncpp/1.9.2
+spdlog/1.5.0
 
 [generators]
 cmake

--- a/src/cpp/scapremai/mapried/sampling/jsoncpp.cpp
+++ b/src/cpp/scapremai/mapried/sampling/jsoncpp.cpp
@@ -41,27 +41,31 @@ std::string message(const char* cc, size_t cc_size, std::string s) {
  */
 std::string value_type_to_string(Json::ValueType value_type) {
   switch (value_type) {
-    case Json::ValueType::nullValue: return "null";
-    case Json::ValueType::intValue: return "int";
-    case Json::ValueType::uintValue: return "uint";
-    case Json::ValueType::realValue: return "real";
-    case Json::ValueType::stringValue: return "string";
-    case Json::ValueType::booleanValue: return "bool";
-    case Json::ValueType::arrayValue: return "array";
-    case Json::ValueType::objectValue: return "object";
+    case Json::ValueType::nullValue:
+      return "null";
+    case Json::ValueType::intValue:
+      return "int";
+    case Json::ValueType::uintValue:
+      return "uint";
+    case Json::ValueType::realValue:
+      return "real";
+    case Json::ValueType::stringValue:
+      return "string";
+    case Json::ValueType::booleanValue:
+      return "bool";
+    case Json::ValueType::arrayValue:
+      return "array";
+    case Json::ValueType::objectValue:
+      return "object";
     default:
       std::stringstream ss;
-      ss << "Unhandled value type in value_to_string: "
-        << value_type;
+      ss << "Unhandled value type in value_to_string: " << value_type;
       throw std::domain_error(ss.str());
   }
 }
 
-void sampling_from(
-    const Json::Value& value,
-    std::string ref,
-    Sampling* target,
-    parse::Errors* errors) {
+void sampling_from(const Json::Value& value, std::string ref, Sampling* target,
+                   parse::Errors* errors) {
   if (errors == nullptr) {
     throw std::invalid_argument("Unexpected null errors");
   }
@@ -71,16 +75,10 @@ void sampling_from(
   }
 
   if (not value.isObject()) {
-    constexpr auto expected_but_got(
-      "Expected an object, but got: ");
+    constexpr auto expected_but_got("Expected an object, but got: ");
 
-    errors->add(
-      ref,
-      message(
-        expected_but_got,
-        strlen(expected_but_got),
-        value_type_to_string(
-          value.type())));
+    errors->add(ref, message(expected_but_got, strlen(expected_but_got),
+                             value_type_to_string(value.type())));
     return;
   }
 
@@ -96,23 +94,16 @@ void sampling_from(
   if (value.isMember("inputs")) {
     const Json::Value& obj = value["inputs"];
     if (not obj.isObject()) {
-      constexpr auto expected_but_got(
-        "Expected an object, but got: ");
+      constexpr auto expected_but_got("Expected an object, but got: ");
 
-      errors->add(
-        inputs_ref,
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            obj.type())));
+      errors->add(inputs_ref,
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(obj.type())));
     } else {
-      for (Json::ValueConstIterator it = obj.begin();
-          it != obj.end(); ++it) {
-                auto instance = std::make_unique<Input>();
+      for (Json::ValueConstIterator it = obj.begin(); it != obj.end(); ++it) {
+        auto instance = std::make_unique<Input>();
         instance->id = it.name();
         target->inputs[it.name()] = std::move(instance);
-
       }
     }
   }
@@ -141,20 +132,12 @@ void sampling_from(
     const Json::Value& obj = value["inputs"];
 
     for (Json::ValueConstIterator it = obj.begin(); it != obj.end(); ++it) {
-      instance_ref.reserve(
-        inputs_ref.size() + 1 + it.name().size());
-      instance_ref.resize(
-        inputs_ref.size() + 1);
-      instance_ref.append(
-        it.name());
+      instance_ref.reserve(inputs_ref.size() + 1 + it.name().size());
+      instance_ref.resize(inputs_ref.size() + 1);
+      instance_ref.append(it.name());
 
-      Input* instance(
-        target->inputs.at(it.name()).get());
-      input_from(
-        *it,
-        instance_ref,
-        instance,
-        errors);
+      Input* instance(target->inputs.at(it.name()).get());
+      input_from(*it, instance_ref, instance, errors);
 
       if (errors->full()) {
         break;
@@ -170,17 +153,11 @@ void sampling_from(
   ////
 
   if (not value.isMember("output")) {
-    errors->add(
-      ref,
-      "Property is missing: output");
+    errors->add(ref, "Property is missing: output");
   } else {
     const Json::Value& value_0 = value["output"];
-    output_from(
-      value_0,
-      std::string(ref)
-        .append("/output"),
-      &target->output,
-      errors);
+    output_from(value_0, std::string(ref).append("/output"), &target->output,
+                errors);
   }
   if (errors->full()) {
     return;
@@ -191,40 +168,28 @@ void sampling_from(
   ////
 
   if (not value.isMember("bins")) {
-    errors->add(
-      ref,
-      "Property is missing: bins");
+    errors->add(ref, "Property is missing: bins");
   } else {
     const Json::Value& value_1 = value["bins"];
     if (not value_1.isInt64()) {
-      constexpr auto expected_but_got(
-        "Expected an int64, but got: ");
+      constexpr auto expected_but_got("Expected an int64, but got: ");
 
-      errors->add(
-        std::string(ref)
-          .append("/bins"),
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            value_1.type())));
+      errors->add(std::string(ref).append("/bins"),
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(value_1.type())));
     } else {
       const auto cast_1 = value_1.asInt64();
       bool ok_1 = true;
 
-      if (not (cast_1 >= 1)) {
+      if (not(cast_1 >= 1)) {
         constexpr auto expected_but_got(
-          "Expected "
-          ">= 1"
-          ", but got: ");
+            "Expected "
+            ">= 1"
+            ", but got: ");
 
-        errors->add(
-          std::string(ref)
-            .append("/bins"),
-          message(
-            expected_but_got,
-            strlen(expected_but_got),
-            std::to_string(cast_1)));
+        errors->add(std::string(ref).append("/bins"),
+                    message(expected_but_got, strlen(expected_but_got),
+                            std::to_string(cast_1)));
         ok_1 = false;
       }
 
@@ -238,22 +203,13 @@ void sampling_from(
   }
 }
 
-void input_from(
-    const Json::Value& value,
-    std::string ref,
-    Input* target,
-    parse::Errors* errors) {
+void input_from(const Json::Value& value, std::string ref, Input* target,
+                parse::Errors* errors) {
   if (not value.isObject()) {
-    constexpr auto expected_but_got(
-      "Expected an object, but got: ");
+    constexpr auto expected_but_got("Expected an object, but got: ");
 
-    errors->add(
-      ref,
-      message(
-        expected_but_got,
-        strlen(expected_but_got),
-        value_type_to_string(
-          value.type())));
+    errors->add(ref, message(expected_but_got, strlen(expected_but_got),
+                             value_type_to_string(value.type())));
     return;
   }
 
@@ -262,23 +218,15 @@ void input_from(
   ////
 
   if (not value.isMember("identifier")) {
-    errors->add(
-      ref,
-      "Property is missing: identifier");
+    errors->add(ref, "Property is missing: identifier");
   } else {
     const Json::Value& value_0 = value["identifier"];
     if (not value_0.isString()) {
-      constexpr auto expected_but_got(
-        "Expected a string, but got: ");
+      constexpr auto expected_but_got("Expected a string, but got: ");
 
-      errors->add(
-        std::string(ref)
-          .append("/identifier"),
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            value_0.type())));
+      errors->add(std::string(ref).append("/identifier"),
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(value_0.type())));
     } else {
       target->identifier = value_0.asString();
     }
@@ -292,23 +240,15 @@ void input_from(
   ////
 
   if (not value.isMember("range_begin")) {
-    errors->add(
-      ref,
-      "Property is missing: range_begin");
+    errors->add(ref, "Property is missing: range_begin");
   } else {
     const Json::Value& value_1 = value["range_begin"];
     if (not value_1.isDouble()) {
-      constexpr auto expected_but_got(
-        "Expected a double, but got: ");
+      constexpr auto expected_but_got("Expected a double, but got: ");
 
-      errors->add(
-        std::string(ref)
-          .append("/range_begin"),
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            value_1.type())));
+      errors->add(std::string(ref).append("/range_begin"),
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(value_1.type())));
     } else {
       target->range_begin = value_1.asDouble();
     }
@@ -322,23 +262,15 @@ void input_from(
   ////
 
   if (not value.isMember("range_end")) {
-    errors->add(
-      ref,
-      "Property is missing: range_end");
+    errors->add(ref, "Property is missing: range_end");
   } else {
     const Json::Value& value_2 = value["range_end"];
     if (not value_2.isDouble()) {
-      constexpr auto expected_but_got(
-        "Expected a double, but got: ");
+      constexpr auto expected_but_got("Expected a double, but got: ");
 
-      errors->add(
-        std::string(ref)
-          .append("/range_end"),
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            value_2.type())));
+      errors->add(std::string(ref).append("/range_end"),
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(value_2.type())));
     } else {
       target->range_end = value_2.asDouble();
     }
@@ -348,22 +280,13 @@ void input_from(
   }
 }
 
-void output_from(
-    const Json::Value& value,
-    std::string ref,
-    Output* target,
-    parse::Errors* errors) {
+void output_from(const Json::Value& value, std::string ref, Output* target,
+                 parse::Errors* errors) {
   if (not value.isObject()) {
-    constexpr auto expected_but_got(
-      "Expected an object, but got: ");
+    constexpr auto expected_but_got("Expected an object, but got: ");
 
-    errors->add(
-      ref,
-      message(
-        expected_but_got,
-        strlen(expected_but_got),
-        value_type_to_string(
-          value.type())));
+    errors->add(ref, message(expected_but_got, strlen(expected_but_got),
+                             value_type_to_string(value.type())));
     return;
   }
 
@@ -372,23 +295,15 @@ void output_from(
   ////
 
   if (not value.isMember("identfier")) {
-    errors->add(
-      ref,
-      "Property is missing: identfier");
+    errors->add(ref, "Property is missing: identfier");
   } else {
     const Json::Value& value_0 = value["identfier"];
     if (not value_0.isString()) {
-      constexpr auto expected_but_got(
-        "Expected a string, but got: ");
+      constexpr auto expected_but_got("Expected a string, but got: ");
 
-      errors->add(
-        std::string(ref)
-          .append("/identfier"),
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            value_0.type())));
+      errors->add(std::string(ref).append("/identfier"),
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(value_0.type())));
     } else {
       target->identfier = value_0.asString();
     }
@@ -402,23 +317,15 @@ void output_from(
   ////
 
   if (not value.isMember("range_begin")) {
-    errors->add(
-      ref,
-      "Property is missing: range_begin");
+    errors->add(ref, "Property is missing: range_begin");
   } else {
     const Json::Value& value_1 = value["range_begin"];
     if (not value_1.isDouble()) {
-      constexpr auto expected_but_got(
-        "Expected a double, but got: ");
+      constexpr auto expected_but_got("Expected a double, but got: ");
 
-      errors->add(
-        std::string(ref)
-          .append("/range_begin"),
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            value_1.type())));
+      errors->add(std::string(ref).append("/range_begin"),
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(value_1.type())));
     } else {
       target->range_begin = value_1.asDouble();
     }
@@ -432,23 +339,15 @@ void output_from(
   ////
 
   if (not value.isMember("range_end")) {
-    errors->add(
-      ref,
-      "Property is missing: range_end");
+    errors->add(ref, "Property is missing: range_end");
   } else {
     const Json::Value& value_2 = value["range_end"];
     if (not value_2.isDouble()) {
-      constexpr auto expected_but_got(
-        "Expected a double, but got: ");
+      constexpr auto expected_but_got("Expected a double, but got: ");
 
-      errors->add(
-        std::string(ref)
-          .append("/range_end"),
-        message(
-          expected_but_got,
-          strlen(expected_but_got),
-          value_type_to_string(
-            value_2.type())));
+      errors->add(std::string(ref).append("/range_end"),
+                  message(expected_but_got, strlen(expected_but_got),
+                          value_type_to_string(value_2.type())));
     } else {
       target->range_end = value_2.asDouble();
     }
@@ -458,8 +357,7 @@ void output_from(
   }
 }
 
-Json::Value serialize_input(
-    const Input& input) {
+Json::Value serialize_input(const Input& input) {
   Json::Value input_as_value;
 
   input_as_value["identifier"] = input.identifier;
@@ -471,8 +369,7 @@ Json::Value serialize_input(
   return input_as_value;
 }
 
-Json::Value serialize_output(
-    const Output& output) {
+Json::Value serialize_output(const Output& output) {
   Json::Value output_as_value;
 
   output_as_value["identfier"] = output.identfier;
@@ -484,8 +381,7 @@ Json::Value serialize_output(
   return output_as_value;
 }
 
-Json::Value serialize_sampling(
-    const Sampling& sampling) {
+Json::Value serialize_sampling(const Sampling& sampling) {
   Json::Value sampling_as_value;
 
   sampling_as_value["output"] = serialize_output(sampling.output);
@@ -500,15 +396,14 @@ Json::Value serialize_sampling(
 
       if (id != instance->id) {
         constexpr auto expected(
-          "Expected the class instance of "
-          "Input"
-          "to have the ID ");
+            "Expected the class instance of "
+            "Input"
+            "to have the ID ");
         constexpr auto but_got(", but got: ");
 
         std::string msg;
-        msg.reserve(
-          strlen(expected) + id.size() +
-          strlen(but_got) + instance->id.size());
+        msg.reserve(strlen(expected) + id.size() + strlen(but_got) +
+                    instance->id.size());
         msg += expected;
         msg += id;
         msg += but_got;

--- a/src/cpp/scapremai/mapried/sampling/jsoncpp.h
+++ b/src/cpp/scapremai/mapried/sampling/jsoncpp.h
@@ -24,11 +24,8 @@ namespace jsoncpp {
  * @param [out] target parsed Sampling
  * @param [out] errors encountered during parsing
  */
-void sampling_from(
-  const Json::Value& value,
-  std::string ref,
-  Sampling* target,
-  parse::Errors* errors);
+void sampling_from(const Json::Value& value, std::string ref, Sampling* target,
+                   parse::Errors* errors);
 
 /**
  * parses Output from a JSON value.
@@ -38,11 +35,8 @@ void sampling_from(
  * @param [out] target parsed data
  * @param [out] errors encountered during parsing
  */
-void output_from(
-  const Json::Value& value,
-  std::string ref,
-  Output* target,
-  parse::Errors* errors);
+void output_from(const Json::Value& value, std::string ref, Output* target,
+                 parse::Errors* errors);
 
 /**
  * parses Input from a JSON value.
@@ -52,12 +46,8 @@ void output_from(
  * @param [out] target parsed data
  * @param [out] errors encountered during parsing
  */
-void input_from(
-  const Json::Value& value,
-  std::string ref,
-  Input* target,
-  parse::Errors* errors);
-
+void input_from(const Json::Value& value, std::string ref, Input* target,
+                parse::Errors* errors);
 
 /**
  * serializes Sampling to a JSON value.
@@ -65,8 +55,7 @@ void input_from(
  * @param sampling to be serialized
  * @return JSON value
  */
-Json::Value serialize_sampling(
-  const Sampling& sampling);
+Json::Value serialize_sampling(const Sampling& sampling);
 
 /**
  * serializes Input to a JSON value.
@@ -74,8 +63,7 @@ Json::Value serialize_sampling(
  * @param input to be serialized
  * @return JSON value
  */
-Json::Value serialize_input(
-  const Input& input);
+Json::Value serialize_input(const Input& input);
 
 /**
  * serializes Output to a JSON value.
@@ -83,8 +71,7 @@ Json::Value serialize_input(
  * @param output to be serialized
  * @return JSON value
  */
-Json::Value serialize_output(
-  const Output& output);
+Json::Value serialize_output(const Output& output);
 
 }  // namespace jsoncpp
 

--- a/src/cpp/scapremai/mapried/sampling/parse.cpp
+++ b/src/cpp/scapremai/mapried/sampling/parse.cpp
@@ -23,17 +23,11 @@ void Errors::add(const std::string& ref, const std::string& message) {
   }
 }
 
-bool Errors::full() const {
-  return errors_.size() == cap_;
-}
+bool Errors::full() const { return errors_.size() == cap_; }
 
-bool Errors::empty() const {
-  return errors_.empty();
-}
+bool Errors::empty() const { return errors_.empty(); }
 
-const std::vector<Error>& Errors::get() const {
-  return errors_;
-}
+const std::vector<Error>& Errors::get() const { return errors_; }
 
 }  // namespace parse
 

--- a/src/cpp/scapremai/mapried/sampling/parse.h
+++ b/src/cpp/scapremai/mapried/sampling/parse.h
@@ -30,7 +30,7 @@ struct Error {
  * at the initialization.
  */
 class Errors {
-public:
+ public:
   explicit Errors(size_t cap);
 
   /**
@@ -39,7 +39,7 @@ public:
    * You need to reserve the space only if you think there will
    * be an excessive amount of errors (e.g., >1000).
    */
-   void reserve(size_t expected_errors);
+  void reserve(size_t expected_errors);
 
   /**
    * adds an error to the container.
@@ -60,7 +60,7 @@ public:
 
   const std::vector<Error>& get() const;
 
-private:
+ private:
   const size_t cap_;
   std::vector<Error> errors_;
 };

--- a/src/cpp/scapremai/mapried/sampling/types.h
+++ b/src/cpp/scapremai/mapried/sampling/types.h
@@ -31,7 +31,7 @@ struct Output {
 
 // defines an input to the model.
 class Input {
-public:
+ public:
   // identifies the instance.
   std::string id;
 

--- a/src/cpp/scapremai/sampler.cpp
+++ b/src/cpp/scapremai/sampler.cpp
@@ -1,6 +1,111 @@
+/**
+ * Sample the data points from a given physical model.
+ */
+
+#include "scapremai/mapried/sampling/jsoncpp.h"
+#include "scapremai/mapried/sampling/parse.h"
+#include "scapremai/mapried/sampling/types.h"
+
+#include <fmt/format.h>
+#include <json/json.h>
+#include <spdlog/spdlog.h>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
 #include <iostream>
 
-int main() {
-  std::cout << "Hello World!";
+namespace fs = boost::filesystem;
+namespace po = boost::program_options;
+
+struct Args {
+  fs::path model_path;
+  fs::path sampling_path;
+  fs::path outdir;
+  bool dont_unwind_stack = false;
+};
+
+int main_impl(const Args& a) {
+  std::ifstream sampling_ifs(a.sampling_path.string());
+  Json::Value sampling_root;
+
+  try {
+    sampling_ifs >> sampling_root;
+  } catch (const std::exception& e) {
+    spdlog::critical("Failed to read sampling specification from %s: %s",
+                     a.sampling_path.string(), e.what());
+    return 1;
+  }
+
+  scapremai::mapried::sampling::Sampling sampling;
+  scapremai::mapried::sampling::parse::Errors errors(1024);
+  scapremai::mapried::sampling::jsoncpp::sampling_from(
+      sampling_root, a.sampling_path.string(), &sampling, &errors);
+
+  if (not errors.empty()) {
+    std::vector<std::string> lines;
+    lines.reserve(1 + errors.get().size());
+    lines.push_back(
+        fmt::format("Failed to parse sampling specification from %s:",
+                    a.sampling_path.string()));
+
+    for (const auto& e : errors.get()) {
+      lines.push_back(fmt::format("%s:%s", e.ref, e.message));
+    }
+
+    spdlog::critical(boost::algorithm::join(lines, "\n"));
+  }
+
   return 0;
+}
+
+int main(int argc, char* argv[]) {
+  Args args;
+
+  po::options_description desc(
+      "Sample the data points from a given physical model");
+
+  auto opts = desc.add_options();
+  opts("model_path", po::value(&args.model_path)->required(),
+       "path to the physical model");
+
+  opts("sampling_path", po::value(&args.sampling_path)->required(),
+       "path to the sampling specification");
+
+  opts("outdir", po::value(&args.outdir)->required(),
+       "path to the output directory");
+
+  opts("dont_unwind_stack",
+       "if specified, the stack will not be unwound. "
+       "Use this only when you need to debug and have to trace the stack!");
+  opts("help,h", "Shows usage");
+
+  po::variables_map varmap;
+  po::store(po::parse_command_line(argc, argv, desc), varmap);
+
+  if (varmap.count("help") != 0) {
+    std::cout << desc << std::endl;
+    return 0;
+  }
+
+  args.dont_unwind_stack = varmap.count("dont_unwind_stack") > 0;
+
+  try {
+    po::notify(varmap);
+  } catch (po::error& err) {
+    std::cerr << err.what() << "\n\n" << desc << std::endl;
+    return 1;
+  }
+
+  if (args.dont_unwind_stack) {
+    main_impl(args);
+  } else {
+    // force stack unwinding
+    try {
+      return main_impl(args);
+    } catch (...) {
+      spdlog::critical("An exception occurred.");
+      throw;
+    }
+  }
 }


### PR DESCRIPTION
This commits introduces a pattern for dealing with program options in the sampler executable. The pattern should allow for easy exchange of the options library. Additionally, there is an example how to load and parse instances of Mapry object graphs.