### PR TITLE
Integrate clang-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,22 @@ conan install ../src/cpp
 
 Run CMake (Linux):
 ```bash
-cmake ../src/cpp -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+cmake \
+    ../src/cpp \
+    -G "Unix Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
 cmake --build .
 ```
 
 or CMake in Windows:
 ```bash
-cmake ../src/cpp -G "Visual Studio 16"
+cmake \
+    ../src/cpp \
+    -G "Visual Studio 16" \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
 cmake --build . --config Release
 ```
 
@@ -69,24 +78,33 @@ make install
 You can overwrite the release directory by supplying `-DCMAKE_INSTALL_PREFIX` 
 to the cmake command.
 
-We check the formatting with clang-format. Please install clang-format separately.
-The following build target fails if the formatting is incorrect. Always run it before
-committing:
+We check the formatting with clang-format. Please install clang-format 
+separately. The following build target fails if the formatting is incorrect. 
+Always run it before committing:
 ```bash
 make format
 ```
 
-Please see https://docs.conan.io/en/latest/getting_started.html for more information on Conan.
+We lint the code with clang-tidy. Please install clang-tidy separately.
+The following build target fails if the linting rules are broken.
+Always run it before comitting:
+```bash
+make tidy
+```
+
+Please see https://docs.conan.io/en/latest/getting_started.html for more 
+information on Conan.
 
 Mapry
 -----
 Mapry schemas go into `src/mapry/`.
 
-The generated code is checked into the repository. These steps are only necessary
-if you want to re-generate the code (*e.g.*, if a schema needs to change).
+The generated code is checked into the repository. These steps are only 
+necessary if you want to re-generate the code (*e.g.*, if a schema needs to 
+change).
 
-To generate the code, first create a Python virtual environment where development
-tools will be installed:
+To generate the code, first create a Python virtual environment where 
+development tools will be installed:
 
 ```bash
 cd {repository root}

--- a/src/cpp/.clang-format
+++ b/src/cpp/.clang-format
@@ -1,23 +1,23 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -1
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
+AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:   
@@ -47,11 +47,11 @@ BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -61,36 +61,34 @@ ForEachMacros:
   - BOOST_FOREACH
 IncludeBlocks:   Preserve
 IncludeCategories: 
-  - Regex:           '^<ext/.*\.h>'
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
-IncludeIsMainRegex: '([-_](test|unittest))?$'
-IndentCaseLabels: true
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
+ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 RawStringFormats: 
   - Delimiter:       pb
@@ -104,13 +102,13 @@ SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
+SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Auto
+Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
 ...

--- a/src/cpp/.clang-tidy
+++ b/src/cpp/.clang-tidy
@@ -1,0 +1,29 @@
+---
+Checks:          '*,-fuchsia-default-arguments'
+WarningsAsErrors: '*'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            marko
+CheckOptions:    
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -18,6 +18,14 @@ endif ()
 add_custom_target(
         format
         COMMAND ${CMAKE_SOURCE_DIR}/run-clang-format.py -r ${CMAKE_SOURCE_DIR}/scapremai
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
+find_program(RUN_CLANG_TIDY_PY NAMES run-clang-tidy-6.0.py run-clang-tidy.py)
+add_custom_target(
+        tidy
+        COMMAND ${RUN_CLANG_TIDY_PY} -p=${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/scapremai
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 
 include_directories(${CMAKE_SOURCE_DIR})

--- a/src/cpp/scapremai/sampler.cpp
+++ b/src/cpp/scapremai/sampler.cpp
@@ -6,12 +6,12 @@
 #include "mapried/sampling/parse.h"
 #include "mapried/sampling/types.h"
 
-#include <fmt/format.h>
-#include <json/json.h>
-#include <spdlog/spdlog.h>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <fmt/format.h>
+#include <json/json.h>
+#include <spdlog/spdlog.h>
 
 #include <iostream>
 


### PR DESCRIPTION
This commit integrates clang-tidy to lint the code base as a build target (`tidy`). The default settings for clang-tidy and clang-format are frozen in .clang-tidy and .clang-format, respectively.